### PR TITLE
Adds figma.children enabling recursive nested codegen.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Translate component variants, properties, and more into dynamic code snippets fo
 - [Templating](#templating)
   - [Symbols](#symbols)
   - [Escaping](#escaping)
+  - [Children](#children)
   - [Conditionals](#conditionals)
   - [Operators](#operators)
   - [Samples](#samples)
@@ -36,10 +37,11 @@ This plugin allows you to write and generate code snippets for Figma nodes, whic
 Snippet templates can represent code in any language. A JSX-style template for a main component like this:
 
 ```
-<Button 
+<Button
   onClick={() => {}}
   variant="{{property.variant}}"
   size="{{property.size}}"
+  iconEnd={<{{property.iconEnd|pascal}} />}
 >
   {{property.label}}
 </Button>
@@ -48,10 +50,11 @@ Snippet templates can represent code in any language. A JSX-style template for a
 ...when filled with a selected component instance's properties, will render an accurate code snippet in Figma like this:
 
 ```jsx
-<Button 
+<Button
   onClick={() => {}}
   variant="primary"
   size="large"
+  iconEnd={<IconArrowRight />}
 >
   Hello World!
 </Button>
@@ -88,6 +91,52 @@ For a line to render, the appropriate data must be present. If `something` was n
 If you need to write the text `"{{something}}"` explicitly in your rendered code, you can escape that text with a single backslash prefix like `"\{{something}}"`.
 
 A more realistic example is the Ember language which requires something like `<Button @label={{t "Value"}} />`. To achieve this, the template would escape the outer brackets with a single prefix. `<Button @label=\{{t "{{something}}"}} />`.
+
+### Children
+
+You may be interested in rendering nested component instances inside your template. `{{figma.children}}` is a special symbol that will render any immediate children inside the template.
+
+These children must have snippet templates defined on themselves with the same title and language as the parent template.
+
+Currently, `figma.children` only looks at immediate children, and will recurse up to 12 levels deep.
+
+Indentation for nested templates infers space or tab indents from the beginning of the line that calls `{{figma.children}}`. For example:
+
+A parent node has the template...
+
+```
+<p>
+  {{figma.children}}
+</p>
+```
+
+...and one of its children has the template...
+
+```
+<span>
+  Hello world!
+</span>
+```
+
+...when the parent is selected, it would render...
+
+```
+<p>
+  <span>
+    Hello world!
+  </span>
+</p>
+```
+
+...and when child is selected, it would render...
+
+```
+<span>
+  Hello world!
+</span>
+```
+
+The two spaces prefixing the `  {{figma.children}}` on the parent template are how the template knows how far in to indent the span.
 
 ### Conditionals
 
@@ -241,14 +290,19 @@ Contains output from [`node.getCSSAsync()`](https://www.figma.com/plugin-docs/ap
 }
 ```
 
+### `figma`
+
+`figma` is not expressed as values in the params object, but rather as the name space for special symbols. Currently [`figma.children`](#children) is the only symbol in this namespace.
+
 ### `node`
 
-Contains the name and type for the selected node. If a Component or ComponentSet, `node.key` will also be provided.
+Contains the name, type, and child count (when applicable) for the selected node. If a Component or ComponentSet, `node.key` will also be provided.
 
 ```json
 {
   "node.name": "icon-heart",
-  "node.type": "instance"
+  "node.type": "instance",
+  "node.children": "0"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ These children must have snippet templates defined on themselves with the same t
 
 Currently, `figma.children` only looks at immediate children, and will recurse up to 12 levels deep.
 
+If you want to render something when there are no children, you can also refer to the [`"node.children"`](#node) param. `{{?node.children=0}}`.
+
 Indentation for nested templates infers space or tab indents from the beginning of the line that calls `{{figma.children}}`. For example:
 
 A parent node has the template...

--- a/code.js
+++ b/code.js
@@ -656,10 +656,7 @@ ${indent}`);
         const hasDefaultMessage = defaultSnippet === "message";
         const currentNode = handleCurrentSelection();
         const paramsMap = await paramsFromNode(currentNode);
-        const nodeSnippetTemplateDataArray = await nodeSnippetTemplateDataArrayFromNode(currentNode, paramsMap, {
-          components: {},
-          types: {}
-        });
+        const nodeSnippetTemplateDataArray = await nodeSnippetTemplateDataArrayFromNode(currentNode, paramsMap, {});
         const snippets = codegenResultsFromNodeSnippetTemplateDataArray(
           nodeSnippetTemplateDataArray,
           isDetailsMode

--- a/code.js
+++ b/code.js
@@ -90,26 +90,28 @@
     `{{([?!])(${regexConditionals})}}`,
     "g"
   );
-  async function nodeSnippetTemplateDataArrayFromNode(node, codeSnippetParamsMap, globalTemplates, indent = "", recursionIndex = 0) {
+  async function nodeSnippetTemplateDataArrayFromNode(node, codeSnippetParamsMap, globalTemplates, indent = "", recursionIndex = 0, parentCodegenResult) {
     const nodeSnippetTemplateDataArray = [];
     const seenSnippetTemplates = {};
-    if (recursionIndex >= 10)
-      return nodeSnippetTemplateDataArray;
     async function processSnippetTemplatesForNode(snippetNode) {
       const codegenResults = getCodegenResultsFromPluginData(snippetNode);
+      const matchingTemplates = (templates) => templates.filter(
+        ({ title, language }) => !parentCodegenResult || title === parentCodegenResult.title && language === parentCodegenResult.language
+      );
+      const matchingCodegenResults = matchingTemplates(codegenResults);
       const codegenResultTemplates = [];
-      if (codegenResults.length) {
-        const seenKey = JSON.stringify(codegenResults);
+      if (matchingCodegenResults.length) {
+        const seenKey = JSON.stringify(matchingCodegenResults);
         if (!seenSnippetTemplates[seenKey]) {
           seenSnippetTemplates[seenKey] = 1;
-          codegenResultTemplates.push(...codegenResults);
+          codegenResultTemplates.push(...matchingCodegenResults);
         }
       }
       if (globalTemplates) {
         const componentTemplates = "key" in snippetNode && globalTemplates.components ? globalTemplates.components[snippetNode.key] || [] : [];
         const typeTemplates = globalTemplates.types ? globalTemplates.types[snippetNode.type] || [] : [];
-        codegenResultTemplates.push(...componentTemplates);
-        codegenResultTemplates.push(...typeTemplates);
+        codegenResultTemplates.push(...matchingTemplates(componentTemplates));
+        codegenResultTemplates.push(...matchingTemplates(typeTemplates));
       }
       const children = "children" in node ? node.children : [];
       const nodeSnippetTemplateData = await hydrateSnippets(
@@ -244,7 +246,8 @@ ${indent}`);
         paramsMap,
         globalTemplates,
         indent,
-        recursionIndex + 1
+        recursionIndex + 1,
+        codegenResult
       );
       const snippet = snippets.map(
         (s) => s.codegenResultArray.find(
@@ -391,6 +394,11 @@ ${indent}`);
     if ("key" in node) {
       paramsRaw["node.key"] = node.key;
       params["node.key"] = node.key;
+    }
+    if ("children" in node) {
+      const childCount = node.children.length.toString();
+      paramsRaw["node.children"] = childCount;
+      params["node.children"] = childCount;
     }
     if (componentNode && "key" in componentNode) {
       paramsRaw["component.key"] = componentNode.key;

--- a/code.js
+++ b/code.js
@@ -75,6 +75,7 @@
   }
 
   // src/snippets.ts
+  var MAX_RECURSION = 12;
   var regexSymbols = /(?<!\\)\{\{([^\{\?\}\|]+)(\|([^\{\?\}]+))?\}\}/g;
   var unescapeBrackets = (line) => line.replace(/\\\{\{/g, "{{");
   var regexConditionalSingle = "([^}&|]+)";
@@ -89,11 +90,13 @@
     `{{([?!])(${regexConditionals})}}`,
     "g"
   );
-  async function nodeSnippetTemplateDataArrayFromNode(node, codeSnippetParamsMap, globalTemplates) {
+  async function nodeSnippetTemplateDataArrayFromNode(node, codeSnippetParamsMap, globalTemplates, indent = "", recursionIndex = 0) {
     const nodeSnippetTemplateDataArray = [];
     const seenSnippetTemplates = {};
-    async function processSnippetTemplatesForNode(node2) {
-      const codegenResults = getCodegenResultsFromPluginData(node2);
+    if (recursionIndex >= 10)
+      return nodeSnippetTemplateDataArray;
+    async function processSnippetTemplatesForNode(snippetNode) {
+      const codegenResults = getCodegenResultsFromPluginData(snippetNode);
       const codegenResultTemplates = [];
       if (codegenResults.length) {
         const seenKey = JSON.stringify(codegenResults);
@@ -103,15 +106,20 @@
         }
       }
       if (globalTemplates) {
-        const componentTemplates = "key" in node2 ? globalTemplates.components[node2.key] || [] : [];
-        const typeTemplates = globalTemplates.types[node2.type] || [];
+        const componentTemplates = "key" in snippetNode && globalTemplates.components ? globalTemplates.components[snippetNode.key] || [] : [];
+        const typeTemplates = globalTemplates.types ? globalTemplates.types[snippetNode.type] || [] : [];
         codegenResultTemplates.push(...componentTemplates);
         codegenResultTemplates.push(...typeTemplates);
       }
+      const children = "children" in node ? node.children : [];
       const nodeSnippetTemplateData = await hydrateSnippets(
         codegenResultTemplates,
         codeSnippetParamsMap,
-        node2.type
+        snippetNode.type,
+        children,
+        indent,
+        recursionIndex,
+        globalTemplates
       );
       nodeSnippetTemplateDataArray.push(nodeSnippetTemplateData);
     }
@@ -147,63 +155,109 @@
     }
     return splitString.join(" ");
   }
-  async function hydrateSnippets(codegenResultTemplatesArray, codeSnippetParamsMap, nodeType) {
+  async function hydrateSnippets(codegenResultTemplatesArray, codeSnippetParamsMap, nodeType, nodeChildren, indent, recursionIndex, globalTemplates) {
     const { paramsRaw, params } = codeSnippetParamsMap;
     const codegenResultArray = [];
     const codegenResultRawTemplatesArray = [];
-    codegenResultTemplatesArray.forEach((codegenResult) => {
-      const lines = codegenResult.code.split("\n");
-      const code = [];
-      lines.forEach((line) => {
-        const [matches, qualifies] = lineConditionalMatch(line, params);
-        matches.forEach((match) => {
-          line = line.replace(match[0], "");
-        });
-        const symbolMatches = [...line.matchAll(regexSymbols)];
-        if (qualifies && symbolMatches.length) {
-          let succeeded = true;
-          symbolMatches.forEach((symbolMatch) => {
-            const [match, param, _, filter] = symbolMatch.map(
-              (a) => a ? a.trim() : a
-            );
-            if (param in params) {
-              const value = transformStringWithFilter(
-                params[param],
-                paramsRaw[param],
-                filter
-              );
-              line = line.replace(match, value);
-            } else if (param === "figma.children") {
-              console.log("HELLO WORLD");
-            } else {
-              succeeded = false;
-            }
+    const resultPromises = codegenResultTemplatesArray.map(
+      async (codegenResult) => {
+        const lines = codegenResult.code.split("\n");
+        const code = [];
+        for (let i = 0; i < lines.length; i++) {
+          let line = lines[i];
+          const [matches, qualifies] = lineConditionalMatch(line, params);
+          matches.forEach((match) => {
+            line = line.replace(match[0], "");
           });
-          if (succeeded) {
+          const symbolMatches = [...line.matchAll(regexSymbols)];
+          if (qualifies && symbolMatches.length) {
+            let succeeded = true;
+            for (let j = 0; j < symbolMatches.length; j++) {
+              const symbolMatch = symbolMatches[j];
+              const [match, param, _, filter] = symbolMatch.map(
+                (a) => a ? a.trim() : a
+              );
+              if (param in params) {
+                const value = transformStringWithFilter(
+                  params[param],
+                  paramsRaw[param],
+                  filter
+                );
+                line = line.replace(match, value);
+              } else if (param === "figma.children" && recursionIndex < MAX_RECURSION) {
+                const indentMatch = line.match(/^[ \t]+/);
+                const indent2 = indentMatch ? indentMatch[0] : "";
+                const value = await findChildrenSnippets(
+                  codegenResult,
+                  nodeChildren,
+                  indent2,
+                  recursionIndex + 1,
+                  globalTemplates
+                );
+                if (value) {
+                  line = line.replace(/^[ \t]+/, "");
+                  line = line.replace(match, value);
+                } else {
+                  succeeded = false;
+                }
+              } else {
+                succeeded = false;
+              }
+            }
+            if (succeeded) {
+              line = unescapeBrackets(line);
+              code.push(line);
+            }
+          } else if (qualifies) {
             line = unescapeBrackets(line);
             code.push(line);
           }
-        } else if (qualifies) {
-          line = unescapeBrackets(line);
-          code.push(line);
         }
-      });
-      const codeString = code.join("\n").replace(/\\\\\n/g, "").replace(/\\\n\\/g, "").replace(/\\\n/g, " ");
-      codegenResultArray.push({
-        title: codegenResult.title,
-        language: codegenResult.language,
-        code: codeString
-      });
-      codegenResultRawTemplatesArray.push({
-        title: `${codegenResult.title}: Template (${nodeType})`,
-        language: "PLAINTEXT",
-        code: codegenResult.code
-      });
-    });
+        const codeString = code.join("\n").replace(/\\\\\n/g, "").replace(/\\\n\\/g, "").replace(/\\\n/g, " ");
+        const indentedCodeString = indent + codeString.replace(/\n/g, `
+${indent}`);
+        codegenResultArray.push({
+          title: codegenResult.title,
+          language: codegenResult.language,
+          code: indentedCodeString
+        });
+        codegenResultRawTemplatesArray.push({
+          title: `${codegenResult.title}: Template (${nodeType})`,
+          language: "PLAINTEXT",
+          code: codegenResult.code
+        });
+        return;
+      }
+    );
+    await Promise.all(resultPromises);
     return {
       codegenResultRawTemplatesArray,
       codegenResultArray
     };
+  }
+  async function findChildrenSnippets(codegenResult, nodeChildren, indent, recursionIndex, globalTemplates) {
+    const string = [];
+    const childPromises = nodeChildren.map(async (child) => {
+      const paramsMap = await paramsFromNode(child);
+      const snippets = await nodeSnippetTemplateDataArrayFromNode(
+        child,
+        paramsMap,
+        globalTemplates,
+        indent,
+        recursionIndex + 1
+      );
+      const snippet = snippets.map(
+        (s) => s.codegenResultArray.find(
+          (r) => r.title === codegenResult.title && r.language === codegenResult.language
+        )
+      ).find(Boolean);
+      if (snippet) {
+        string.push(snippet.code);
+      }
+      return;
+    });
+    await Promise.all(childPromises);
+    return string.join("\n");
   }
   function lineConditionalMatch(line, params) {
     const matches = [...line.matchAll(regexConditional)];
@@ -594,7 +648,10 @@
         const hasDefaultMessage = defaultSnippet === "message";
         const currentNode = handleCurrentSelection();
         const paramsMap = await paramsFromNode(currentNode);
-        const nodeSnippetTemplateDataArray = await nodeSnippetTemplateDataArrayFromNode(currentNode, paramsMap);
+        const nodeSnippetTemplateDataArray = await nodeSnippetTemplateDataArrayFromNode(currentNode, paramsMap, {
+          components: {},
+          types: {}
+        });
         const snippets = codegenResultsFromNodeSnippetTemplateDataArray(
           nodeSnippetTemplateDataArray,
           isDetailsMode

--- a/src/code.ts
+++ b/src/code.ts
@@ -66,10 +66,7 @@ function initializeCodegenMode() {
 
       const paramsMap = await paramsFromNode(currentNode);
       const nodeSnippetTemplateDataArray =
-        await nodeSnippetTemplateDataArrayFromNode(currentNode, paramsMap, {
-          components: {},
-          types: {},
-        });
+        await nodeSnippetTemplateDataArrayFromNode(currentNode, paramsMap, {});
 
       const snippets = codegenResultsFromNodeSnippetTemplateDataArray(
         nodeSnippetTemplateDataArray,

--- a/src/code.ts
+++ b/src/code.ts
@@ -66,7 +66,10 @@ function initializeCodegenMode() {
 
       const paramsMap = await paramsFromNode(currentNode);
       const nodeSnippetTemplateDataArray =
-        await nodeSnippetTemplateDataArrayFromNode(currentNode, paramsMap);
+        await nodeSnippetTemplateDataArrayFromNode(currentNode, paramsMap, {
+          components: {},
+          types: {},
+        });
 
       const snippets = codegenResultsFromNodeSnippetTemplateDataArray(
         nodeSnippetTemplateDataArray,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -4,8 +4,8 @@
  *  "types" is a map binding  NodeTypes to codegen result arrays.
  */
 type CodeSnippetGlobalTemplates = {
-  components: CodegenResultTemplatesByComponentKey;
-  types: { [K in NodeType]?: CodegenResult[] };
+  components?: CodegenResultTemplatesByComponentKey;
+  types?: { [K in NodeType]?: CodegenResult[] };
 };
 
 /**

--- a/src/params.ts
+++ b/src/params.ts
@@ -136,6 +136,11 @@ async function initialParamsFromNode(
     paramsRaw["node.key"] = node.key;
     params["node.key"] = node.key;
   }
+  if ("children" in node) {
+    const childCount = node.children.length.toString();
+    paramsRaw["node.children"] = childCount;
+    params["node.children"] = childCount;
+  }
   if (componentNode && "key" in componentNode) {
     paramsRaw["component.key"] = componentNode.key;
     paramsRaw["component.type"] = componentNode.type;

--- a/src/snippets.ts
+++ b/src/snippets.ts
@@ -1,6 +1,10 @@
 import { paramsFromNode } from "./params";
 import { getCodegenResultsFromPluginData } from "./pluginData";
 
+/**
+ * The maximum depth we can recurse through children.
+ * Hitting this limit would require nesting 12 nodes deep where all have a template.
+ */
 const MAX_RECURSION = 12;
 
 /**

--- a/src/snippets.ts
+++ b/src/snippets.ts
@@ -1,4 +1,7 @@
+import { paramsFromNode } from "./params";
 import { getCodegenResultsFromPluginData } from "./pluginData";
+
+const MAX_RECURSION = 12;
 
 /**
  * Regular expression for finding symbols, aka {{property.variant}} in a string.
@@ -55,15 +58,20 @@ const regexConditional = new RegExp(
  * For component-like nodes, this will discover inherited templates (component set > component > instance).
  * @param node the node to find relevant snippets for from plugin data
  * @param codeSnippetParamsMap the map of params that can fill the templates
+ * @param globalTemplates CodeSnippetGlobalTemplates
+ * @param indent optional indent level to prepend to each line
  * @returns NodeSnippetTemplateData array containing hydrated snippets for the current node.
  */
 export async function nodeSnippetTemplateDataArrayFromNode(
   node: SceneNode,
   codeSnippetParamsMap: CodeSnippetParamsMap,
-  globalTemplates?: CodeSnippetGlobalTemplates
+  globalTemplates: CodeSnippetGlobalTemplates,
+  indent: string = "",
+  recursionIndex = 0
 ): Promise<NodeSnippetTemplateData[]> {
   const nodeSnippetTemplateDataArray: NodeSnippetTemplateData[] = [];
   const seenSnippetTemplates: { [k: string]: number } = {};
+  if (recursionIndex >= 10) return nodeSnippetTemplateDataArray;
 
   /**
    * Process snippets for any node. Called multiple times up the lineage for component and instance nodes.
@@ -72,8 +80,8 @@ export async function nodeSnippetTemplateDataArrayFromNode(
    * @param node the node to check for templates in plugin data
    * @returns Promise<void> will push into nodeSnippetTemplateDataArray.
    */
-  async function processSnippetTemplatesForNode(node: SceneNode) {
-    const codegenResults = getCodegenResultsFromPluginData(node);
+  async function processSnippetTemplatesForNode(snippetNode: SceneNode) {
+    const codegenResults = getCodegenResultsFromPluginData(snippetNode);
     const codegenResultTemplates: CodegenResult[] = [];
     if (codegenResults.length) {
       const seenKey = JSON.stringify(codegenResults);
@@ -84,15 +92,24 @@ export async function nodeSnippetTemplateDataArrayFromNode(
     }
     if (globalTemplates) {
       const componentTemplates =
-        "key" in node ? globalTemplates.components[node.key] || [] : [];
-      const typeTemplates = globalTemplates.types[node.type] || [];
+        "key" in snippetNode && globalTemplates.components
+          ? globalTemplates.components[snippetNode.key] || []
+          : [];
+      const typeTemplates = globalTemplates.types
+        ? globalTemplates.types[snippetNode.type] || []
+        : [];
       codegenResultTemplates.push(...componentTemplates);
       codegenResultTemplates.push(...typeTemplates);
     }
+    const children = "children" in node ? node.children : [];
     const nodeSnippetTemplateData = await hydrateSnippets(
       codegenResultTemplates,
       codeSnippetParamsMap,
-      node.type
+      snippetNode.type,
+      children,
+      indent,
+      recursionIndex,
+      globalTemplates
     );
     nodeSnippetTemplateDataArray.push(nodeSnippetTemplateData);
   }
@@ -164,83 +181,163 @@ export function transformStringWithFilter(
  * Fill templates with code snippet params.
  * @param codegenResultTemplatesArray codegen result array of templates loaded from pluginData or global templates.
  * @param codeSnippetParamsMap the map of raw and sanitized params used to hydrate the template.
+ * @param nodeType string for the type of node the template is coming from. used in the title in details mode.
+ * @param children an array of child nodes
+ * @param indent the string to use for indent on children
+ * @param recursionIndex how deep are we in recursion
+ * @param globalTemplates the global templates object for component key or node type based templates
  * @returns a Promise resolving NodeSnippetTemplateData
  */
 export async function hydrateSnippets(
   codegenResultTemplatesArray: CodegenResult[],
   codeSnippetParamsMap: CodeSnippetParamsMap,
-  nodeType: string
+  nodeType: string,
+  nodeChildren: readonly SceneNode[],
+  indent: string,
+  recursionIndex: number,
+  globalTemplates: CodeSnippetGlobalTemplates
 ): Promise<NodeSnippetTemplateData> {
   const { paramsRaw, params } = codeSnippetParamsMap;
   const codegenResultArray: CodegenResult[] = [];
   const codegenResultRawTemplatesArray: CodegenResult[] = [];
 
-  codegenResultTemplatesArray.forEach((codegenResult) => {
-    const lines = codegenResult.code.split("\n");
-    const code: string[] = [];
-    lines.forEach((line) => {
-      const [matches, qualifies] = lineConditionalMatch(line, params);
-      matches.forEach((match) => {
-        line = line.replace(match[0], "");
-      });
-
-      const symbolMatches = [...line.matchAll(regexSymbols)];
-      if (qualifies && symbolMatches.length) {
-        let succeeded = true;
-        symbolMatches.forEach((symbolMatch) => {
-          const [match, param, _, filter] = symbolMatch.map((a) =>
-            a ? a.trim() : a
-          ) as [string, string, string, SnippetStringFilter];
-          if (param in params) {
-            const value = transformStringWithFilter(
-              params[param],
-              paramsRaw[param],
-              filter
-            );
-            line = line.replace(match, value);
-          } else if (param === "figma.children") {
-            console.log("HELLO WORLD");
-          } else {
-            succeeded = false;
-          }
+  const resultPromises = codegenResultTemplatesArray.map(
+    async (codegenResult) => {
+      const lines = codegenResult.code.split("\n");
+      const code: string[] = [];
+      for (let i = 0; i < lines.length; i++) {
+        let line = lines[i];
+        const [matches, qualifies] = lineConditionalMatch(line, params);
+        matches.forEach((match) => {
+          line = line.replace(match[0], "");
         });
-        if (succeeded) {
+
+        const symbolMatches = [...line.matchAll(regexSymbols)];
+        if (qualifies && symbolMatches.length) {
+          let succeeded = true;
+          for (let j = 0; j < symbolMatches.length; j++) {
+            const symbolMatch = symbolMatches[j];
+            const [match, param, _, filter] = symbolMatch.map((a) =>
+              a ? a.trim() : a
+            ) as [string, string, string, SnippetStringFilter];
+            if (param in params) {
+              const value = transformStringWithFilter(
+                params[param],
+                paramsRaw[param],
+                filter
+              );
+              line = line.replace(match, value);
+            } else if (
+              param === "figma.children" &&
+              recursionIndex < MAX_RECURSION
+            ) {
+              const indentMatch = line.match(/^[ \t]+/);
+              const indent = indentMatch ? indentMatch[0] : "";
+              const value = await findChildrenSnippets(
+                codegenResult,
+                nodeChildren,
+                indent,
+                recursionIndex + 1,
+                globalTemplates
+              );
+              if (value) {
+                line = line.replace(/^[ \t]+/, "");
+                line = line.replace(match, value);
+              } else {
+                succeeded = false;
+              }
+            } else {
+              succeeded = false;
+            }
+          }
+
+          if (succeeded) {
+            line = unescapeBrackets(line);
+            code.push(line);
+          }
+        } else if (qualifies) {
           line = unescapeBrackets(line);
           code.push(line);
         }
-      } else if (qualifies) {
-        line = unescapeBrackets(line);
-        code.push(line);
       }
-    });
 
-    /**
-     * Single line syntax collapses "/" prefix and suffix into single line spaces
-     * https://github.com/figma/code-snippet-editor-plugin#single-line-syntax
-     */
-    const codeString = code
-      .join("\n")
-      .replace(/\\\\\n/g, "") // collapse single line leading space
-      .replace(/\\\n\\/g, "") // collapse single line trailing space
-      .replace(/\\\n/g, " "); // collapse single line
+      /**
+       * Single line syntax collapses "/" prefix and suffix into single line spaces
+       * https://github.com/figma/code-snippet-editor-plugin#single-line-syntax
+       */
+      const codeString = code
+        .join("\n")
+        .replace(/\\\\\n/g, "") // collapse single line leading space
+        .replace(/\\\n\\/g, "") // collapse single line trailing space
+        .replace(/\\\n/g, " "); // collapse single line
 
-    codegenResultArray.push({
-      title: codegenResult.title,
-      language: codegenResult.language,
-      code: codeString,
-    });
+      /**
+       * Prepend indent to every line.
+       */
+      const indentedCodeString =
+        indent + codeString.replace(/\n/g, `\n${indent}`);
 
-    codegenResultRawTemplatesArray.push({
-      title: `${codegenResult.title}: Template (${nodeType})`,
-      language: "PLAINTEXT",
-      code: codegenResult.code,
-    });
-  });
+      codegenResultArray.push({
+        title: codegenResult.title,
+        language: codegenResult.language,
+        code: indentedCodeString,
+      });
+
+      codegenResultRawTemplatesArray.push({
+        title: `${codegenResult.title}: Template (${nodeType})`,
+        language: "PLAINTEXT",
+        code: codegenResult.code,
+      });
+
+      return;
+    }
+  );
+
+  await Promise.all(resultPromises);
 
   return {
     codegenResultRawTemplatesArray,
     codegenResultArray,
   };
+}
+
+/**
+ *
+ */
+async function findChildrenSnippets(
+  codegenResult: CodegenResult,
+  nodeChildren: readonly SceneNode[],
+  indent: string,
+  recursionIndex: number,
+  globalTemplates: CodeSnippetGlobalTemplates
+): Promise<string> {
+  const string: string[] = [];
+  const childPromises = nodeChildren.map(async (child) => {
+    const paramsMap = await paramsFromNode(child);
+    // TODO: parameter for this function to filter out irrelevant templates.
+    const snippets = await nodeSnippetTemplateDataArrayFromNode(
+      child,
+      paramsMap,
+      globalTemplates,
+      indent,
+      recursionIndex + 1
+    );
+    const snippet = snippets
+      .map((s) =>
+        s.codegenResultArray.find(
+          (r) =>
+            r.title === codegenResult.title &&
+            r.language === codegenResult.language
+        )
+      )
+      .find(Boolean);
+    if (snippet) {
+      string.push(snippet.code);
+    }
+    return;
+  });
+  await Promise.all(childPromises);
+  return string.join("\n");
 }
 
 /**

--- a/src/test.ts
+++ b/src/test.ts
@@ -14,6 +14,8 @@ const SNIPPET_TESTS = {
   "{{!1=1}}not1": "",
   "{{!1=2}}not1": "not1",
   "{{?1=1&2=2}}{{!hello=cheese}}compound": "compound",
+  "{{1}}{{hello}}{{2}}": "1world2",
+  "{{1}}{{invalid}}{{2}}": "",
 };
 
 const SNIPPET_TEST_CODE = Object.keys(SNIPPET_TESTS).join("\n");
@@ -34,7 +36,11 @@ async function testSnippets() {
   const result = await hydrateSnippets(
     [{ language: "PLAINTEXT", code: SNIPPET_TEST_CODE, title: "test" }],
     { params: SNIPPET_TEST_PARAMS, paramsRaw: SNIPPET_TEST_PARAMS },
-    "INSTANCE"
+    "INSTANCE",
+    [],
+    "",
+    0,
+    {}
   );
   const code = result.codegenResultArray[0].code;
   if (code === SNIPPET_TEST_CODE_EXPECTATION) {

--- a/src/test.ts
+++ b/src/test.ts
@@ -14,6 +14,8 @@ const SNIPPET_TESTS = {
   "{{!1=1}}not1": "",
   "{{!1=2}}not1": "not1",
   "{{?1=1&2=2}}{{!hello=cheese}}compound": "compound",
+  "{{figma.children}}": "",
+  "Hello, {{figma.children}}": "",
   "{{1}}{{hello}}{{2}}": "1world2",
   "{{1}}{{invalid}}{{2}}": "",
 };

--- a/test.js
+++ b/test.js
@@ -530,6 +530,8 @@ ${indent}`);
     "{{!1=1}}not1": "",
     "{{!1=2}}not1": "not1",
     "{{?1=1&2=2}}{{!hello=cheese}}compound": "compound",
+    "{{figma.children}}": "",
+    "Hello, {{figma.children}}": "",
     "{{1}}{{hello}}{{2}}": "1world2",
     "{{1}}{{invalid}}{{2}}": ""
   };

--- a/test.js
+++ b/test.js
@@ -1,6 +1,296 @@
 "use strict";
 (() => {
+  // src/params.ts
+  async function paramsFromNode(node, propertiesOnly = false) {
+    const { componentPropValuesMap, instanceParamsMap } = await componentPropertyDataFromNode(node);
+    const params = {};
+    const paramsRaw = {};
+    for (let key in componentPropValuesMap) {
+      const item = componentPropValuesMap[key];
+      const itemKeys = Object.keys(item);
+      if (itemKeys.length > 1) {
+        itemKeys.forEach((type) => {
+          const value = `${item[type]}`;
+          const lowerChar = type.charAt(0).toLowerCase();
+          params[`property.${key}.${lowerChar}`] = safeString(value);
+          paramsRaw[`property.${key}.${lowerChar}`] = value;
+        });
+      } else {
+        const value = `${item[itemKeys[0]]}`;
+        params[`property.${key}`] = safeString(value);
+        paramsRaw[`property.${key}`] = value;
+      }
+      if (itemKeys.includes("INSTANCE_SWAP") && instanceParamsMap[key]) {
+        const keyPrefix = itemKeys.length > 1 ? `property.${key}.i` : `property.${key}`;
+        for (let k in instanceParamsMap[key].params) {
+          params[`${keyPrefix}.${k}`] = safeString(
+            instanceParamsMap[key].params[k]
+          );
+          paramsRaw[`${keyPrefix}.${k}`] = instanceParamsMap[key].paramsRaw[k];
+        }
+      }
+    }
+    if (propertiesOnly) {
+      return { params, paramsRaw };
+    }
+    const initial = await initialParamsFromNode(node);
+    return {
+      params: Object.assign(params, initial.params),
+      paramsRaw: Object.assign(paramsRaw, initial.paramsRaw)
+    };
+  }
+  async function componentPropertyDataFromNode(node) {
+    const componentPropObject = componentPropObjectFromNode(node);
+    const componentPropValuesMap = {};
+    const isDefinitions = isComponentPropertyDefinitionsObject(componentPropObject);
+    const instanceParamsMap = {};
+    for (let propertyName in componentPropObject) {
+      const value = isDefinitions ? componentPropObject[propertyName].defaultValue : componentPropObject[propertyName].value;
+      const type = componentPropObject[propertyName].type;
+      const cleanName = sanitizePropertyName(propertyName);
+      if (value !== void 0) {
+        componentPropValuesMap[cleanName] = componentPropValuesMap[cleanName] || {};
+        if (typeof value === "string") {
+          if (type === "VARIANT")
+            componentPropValuesMap[cleanName].VARIANT = value;
+          if (type === "TEXT")
+            componentPropValuesMap[cleanName].TEXT = value;
+          if (type === "INSTANCE_SWAP") {
+            const foundNode = await figma.getNodeById(value);
+            const nodeName = nameFromFoundInstanceSwapNode(foundNode);
+            componentPropValuesMap[cleanName].INSTANCE_SWAP = nodeName;
+            if (foundNode) {
+              instanceParamsMap[cleanName] = await paramsFromNode(
+                foundNode,
+                true
+              );
+            }
+          }
+        } else {
+          componentPropValuesMap[cleanName].BOOLEAN = value;
+        }
+      }
+    }
+    return { componentPropValuesMap, instanceParamsMap };
+  }
+  function nameFromFoundInstanceSwapNode(node) {
+    return node && node.parent && node.parent.type === "COMPONENT_SET" ? node.parent.name : node ? node.name : "";
+  }
+  async function initialParamsFromNode(node) {
+    const componentNode = getComponentNodeFromNode(node);
+    const css = await node.getCSSAsync();
+    const autolayout = "inferredAutoLayout" in node ? node.inferredAutoLayout : void 0;
+    const paramsRaw = {
+      "node.name": node.name,
+      "node.type": node.type
+    };
+    const params = {
+      "node.name": safeString(node.name),
+      "node.type": safeString(node.type)
+    };
+    if ("key" in node) {
+      paramsRaw["node.key"] = node.key;
+      params["node.key"] = node.key;
+    }
+    if (componentNode && "key" in componentNode) {
+      paramsRaw["component.key"] = componentNode.key;
+      paramsRaw["component.type"] = componentNode.type;
+      paramsRaw["component.name"] = componentNode.name;
+      params["component.key"] = componentNode.key;
+      params["component.type"] = safeString(componentNode.type);
+      params["component.name"] = safeString(componentNode.name);
+    }
+    for (let key in css) {
+      const k = transformStringWithFilter(key, key, "camel");
+      params[`css.${k}`] = css[key];
+      paramsRaw[`css.${k}`] = css[key];
+    }
+    if ("boundVariables" in node && node.boundVariables) {
+      const boundVariables = node.boundVariables;
+      for (let key in boundVariables) {
+        let vars = boundVariables[key];
+        if (vars) {
+          if (!Array.isArray(vars)) {
+            vars = [vars];
+          }
+          vars.forEach((v) => {
+            const va = figma.variables.getVariableById(v.id);
+            if (va) {
+              paramsRaw[`variables.${key}`] = va.name;
+              params[`variables.${key}`] = safeString(va.name);
+              for (let syntax in va.codeSyntax) {
+                const syntaxKey = syntax.charAt(0).toLowerCase();
+                const syntaxName = syntax;
+                const value = va.codeSyntax[syntaxName];
+                if (value) {
+                  paramsRaw[`variables.${key}.${syntaxKey}`] = value;
+                  params[`variables.${key}.${syntaxKey}`] = safeString(value);
+                }
+              }
+            }
+          });
+        }
+      }
+    }
+    if (autolayout) {
+      const props = [
+        "layoutMode",
+        "layoutWrap",
+        "paddingLeft",
+        "paddingRight",
+        "paddingTop",
+        "paddingBottom",
+        "itemSpacing",
+        "counterAxisSpacing",
+        "primaryAxisAlignItems",
+        "counterAxisAlignItems"
+      ];
+      props.forEach((p) => {
+        const val = autolayout[p] + "";
+        if (val !== "undefined" && val !== "null") {
+          paramsRaw[`autolayout.${p}`] = val;
+          params[`autolayout.${p}`] = safeString(val);
+        }
+      });
+    }
+    return { params, paramsRaw };
+  }
+  function isComponentPropertyDefinitionsObject(object) {
+    return object[Object.keys(object)[0]] && "defaultValue" in object[Object.keys(object)[0]];
+  }
+  function componentPropObjectFromNode(node) {
+    if (node.type === "INSTANCE")
+      return node.componentProperties;
+    if (node.type === "COMPONENT_SET")
+      return node.componentPropertyDefinitions;
+    if (node.type === "COMPONENT") {
+      if (node.parent && node.parent.type === "COMPONENT_SET") {
+        const initialProps = Object.assign(
+          {},
+          node.parent.componentPropertyDefinitions
+        );
+        const nameProps = node.name.split(", ");
+        nameProps.forEach((prop) => {
+          const [propName, propValue] = prop.split("=");
+          initialProps[propName].defaultValue = propValue;
+        });
+        return initialProps;
+      } else {
+        return node.componentPropertyDefinitions;
+      }
+    }
+    return {};
+  }
+  function capitalize(name) {
+    return `${name.charAt(0).toUpperCase()}${name.slice(1)}`;
+  }
+  function downcase(name) {
+    return `${name.charAt(0).toLowerCase()}${name.slice(1)}`;
+  }
+  function numericGuard(name = "") {
+    if (name.charAt(0).match(/\d/)) {
+      name = `N${name}`;
+    }
+    return name;
+  }
+  function capitalizedNameFromName(name = "") {
+    name = numericGuard(name);
+    return name.split(/[^a-zA-Z\d]+/g).map(capitalize).join("");
+  }
+  function sanitizePropertyName(name) {
+    name = name.replace(/#[^#]+$/g, "");
+    return downcase(capitalizedNameFromName(name).replace(/^\d+/g, ""));
+  }
+  function getComponentNodeFromNode(node) {
+    const { type, parent } = node;
+    const parentType = parent ? parent.type : "";
+    const isVariant = parentType === "COMPONENT_SET";
+    if (type === "COMPONENT_SET" || type === "COMPONENT" && !isVariant) {
+      return node;
+    } else if (node.type === "COMPONENT" && node.parent && node.parent.type === "COMPONENT_SET") {
+      return node.parent;
+    } else if (type === "INSTANCE") {
+      const { mainComponent } = node;
+      return mainComponent ? mainComponent.parent && mainComponent.parent.type === "COMPONENT_SET" ? mainComponent.parent : mainComponent : null;
+    }
+    return null;
+  }
+  function safeString(string = "") {
+    string = string.replace(/([^a-zA-Z0-9-_// ])/g, "");
+    if (!string.match(/^[A-Z0-9_]+$/)) {
+      string = string.replace(/([A-Z])/g, " $1");
+    }
+    return string.replace(/([a-z])([0-9])/g, "$1 $2").replace(/([-_/])/g, " ").replace(/  +/g, " ").trim().toLowerCase().split(" ").join("-");
+  }
+
+  // src/pluginData.ts
+  var PLUGIN_DATA_NAMESPACE = "codesnippets";
+  var PLUGIN_DATA_KEY = "snippets";
+  var CODEGEN_LANGUAGES = [
+    "BASH",
+    "CPP",
+    "CSS",
+    "GO",
+    "GRAPHQL",
+    "HTML",
+    "JAVASCRIPT",
+    "JSON",
+    "KOTLIN",
+    "PLAINTEXT",
+    "PYTHON",
+    "RUBY",
+    "RUST",
+    "SQL",
+    "SWIFT",
+    "TYPESCRIPT"
+  ];
+  function getCodegenResultsFromPluginData(node) {
+    const pluginData = node.getSharedPluginData(
+      PLUGIN_DATA_NAMESPACE,
+      PLUGIN_DATA_KEY
+    );
+    return pluginDataStringAsValidCodegenResults(pluginData) || [];
+  }
+  function valueIsCodegenLanguage(value) {
+    return CODEGEN_LANGUAGES.includes(value);
+  }
+  function objectIsCodegenResult(object) {
+    if (typeof object !== "object")
+      return false;
+    if (Object.keys(object).length !== 3)
+      return false;
+    if (!("title" in object && "code" in object && "language" in object))
+      return false;
+    if (typeof object.title !== "string" || typeof object.code !== "string")
+      return false;
+    return valueIsCodegenLanguage(object.language);
+  }
+  function arrayContainsCodegenResults(array) {
+    let valid = true;
+    if (Array.isArray(array)) {
+      array.forEach((object) => {
+        if (!objectIsCodegenResult(object)) {
+          valid = false;
+        }
+      });
+    } else {
+      valid = false;
+    }
+    return valid;
+  }
+  function pluginDataStringAsValidCodegenResults(pluginDataString) {
+    if (!pluginDataString)
+      return null;
+    try {
+      const parsed = JSON.parse(pluginDataString);
+      return arrayContainsCodegenResults(parsed) ? parsed : null;
+    } catch (e) {
+      return null;
+    }
+  }
+
   // src/snippets.ts
+  var MAX_RECURSION = 12;
   var regexSymbols = /(?<!\\)\{\{([^\{\?\}\|]+)(\|([^\{\?\}]+))?\}\}/g;
   var unescapeBrackets = (line) => line.replace(/\\\{\{/g, "{{");
   var regexConditionalSingle = "([^}&|]+)";
@@ -15,18 +305,64 @@
     `{{([?!])(${regexConditionals})}}`,
     "g"
   );
+  async function nodeSnippetTemplateDataArrayFromNode(node, codeSnippetParamsMap, globalTemplates, indent = "", recursionIndex = 0) {
+    const nodeSnippetTemplateDataArray = [];
+    const seenSnippetTemplates = {};
+    if (recursionIndex >= 10)
+      return nodeSnippetTemplateDataArray;
+    async function processSnippetTemplatesForNode(snippetNode) {
+      const codegenResults = getCodegenResultsFromPluginData(snippetNode);
+      const codegenResultTemplates = [];
+      if (codegenResults.length) {
+        const seenKey = JSON.stringify(codegenResults);
+        if (!seenSnippetTemplates[seenKey]) {
+          seenSnippetTemplates[seenKey] = 1;
+          codegenResultTemplates.push(...codegenResults);
+        }
+      }
+      if (globalTemplates) {
+        const componentTemplates = "key" in snippetNode && globalTemplates.components ? globalTemplates.components[snippetNode.key] || [] : [];
+        const typeTemplates = globalTemplates.types ? globalTemplates.types[snippetNode.type] || [] : [];
+        codegenResultTemplates.push(...componentTemplates);
+        codegenResultTemplates.push(...typeTemplates);
+      }
+      const children = "children" in node ? node.children : [];
+      const nodeSnippetTemplateData = await hydrateSnippets(
+        codegenResultTemplates,
+        codeSnippetParamsMap,
+        snippetNode.type,
+        children,
+        indent,
+        recursionIndex,
+        globalTemplates
+      );
+      nodeSnippetTemplateDataArray.push(nodeSnippetTemplateData);
+    }
+    await processSnippetTemplatesForNode(node);
+    if (node.type === "INSTANCE") {
+      if (node.mainComponent) {
+        await processSnippetTemplatesForNode(node.mainComponent);
+        if (node.mainComponent.parent && node.mainComponent.parent.type === "COMPONENT_SET") {
+          await processSnippetTemplatesForNode(node.mainComponent.parent);
+        }
+      }
+    } else if (node.type === "COMPONENT" && node.parent && node.parent.type === "COMPONENT_SET") {
+      await processSnippetTemplatesForNode(node.parent);
+    }
+    return nodeSnippetTemplateDataArray;
+  }
   function transformStringWithFilter(string, rawString, filter = "hyphen") {
     const splitString = string.split("-");
-    const capitalize = (s) => s.charAt(0).toUpperCase() + s.substring(1);
+    const capitalize2 = (s) => s.charAt(0).toUpperCase() + s.substring(1);
     switch (filter) {
       case "camel":
-        return splitString.map((word, i) => i === 0 ? word : capitalize(word)).join("");
+        return splitString.map((word, i) => i === 0 ? word : capitalize2(word)).join("");
       case "constant":
         return splitString.join("_").toUpperCase();
       case "hyphen":
         return splitString.join("-").toLowerCase();
       case "pascal":
-        return splitString.map(capitalize).join("");
+        return splitString.map(capitalize2).join("");
       case "raw":
         return rawString;
       case "snake":
@@ -34,63 +370,109 @@
     }
     return splitString.join(" ");
   }
-  async function hydrateSnippets(codegenResultTemplatesArray, codeSnippetParamsMap, nodeType) {
+  async function hydrateSnippets(codegenResultTemplatesArray, codeSnippetParamsMap, nodeType, nodeChildren, indent, recursionIndex, globalTemplates) {
     const { paramsRaw, params } = codeSnippetParamsMap;
     const codegenResultArray = [];
     const codegenResultRawTemplatesArray = [];
-    codegenResultTemplatesArray.forEach((codegenResult) => {
-      const lines = codegenResult.code.split("\n");
-      const code = [];
-      lines.forEach((line) => {
-        const [matches, qualifies] = lineConditionalMatch(line, params);
-        matches.forEach((match) => {
-          line = line.replace(match[0], "");
-        });
-        const symbolMatches = [...line.matchAll(regexSymbols)];
-        if (qualifies && symbolMatches.length) {
-          let succeeded = true;
-          symbolMatches.forEach((symbolMatch) => {
-            const [match, param, _, filter] = symbolMatch.map(
-              (a) => a ? a.trim() : a
-            );
-            if (param in params) {
-              const value = transformStringWithFilter(
-                params[param],
-                paramsRaw[param],
-                filter
-              );
-              line = line.replace(match, value);
-            } else if (param === "figma.children") {
-              console.log("HELLO WORLD");
-            } else {
-              succeeded = false;
-            }
+    const resultPromises = codegenResultTemplatesArray.map(
+      async (codegenResult) => {
+        const lines = codegenResult.code.split("\n");
+        const code = [];
+        for (let i = 0; i < lines.length; i++) {
+          let line = lines[i];
+          const [matches, qualifies] = lineConditionalMatch(line, params);
+          matches.forEach((match) => {
+            line = line.replace(match[0], "");
           });
-          if (succeeded) {
+          const symbolMatches = [...line.matchAll(regexSymbols)];
+          if (qualifies && symbolMatches.length) {
+            let succeeded = true;
+            for (let j = 0; j < symbolMatches.length; j++) {
+              const symbolMatch = symbolMatches[j];
+              const [match, param, _, filter] = symbolMatch.map(
+                (a) => a ? a.trim() : a
+              );
+              if (param in params) {
+                const value = transformStringWithFilter(
+                  params[param],
+                  paramsRaw[param],
+                  filter
+                );
+                line = line.replace(match, value);
+              } else if (param === "figma.children" && recursionIndex < MAX_RECURSION) {
+                const indentMatch = line.match(/^[ \t]+/);
+                const indent2 = indentMatch ? indentMatch[0] : "";
+                const value = await findChildrenSnippets(
+                  codegenResult,
+                  nodeChildren,
+                  indent2,
+                  recursionIndex + 1,
+                  globalTemplates
+                );
+                if (value) {
+                  line = line.replace(/^[ \t]+/, "");
+                  line = line.replace(match, value);
+                } else {
+                  succeeded = false;
+                }
+              } else {
+                succeeded = false;
+              }
+            }
+            if (succeeded) {
+              line = unescapeBrackets(line);
+              code.push(line);
+            }
+          } else if (qualifies) {
             line = unescapeBrackets(line);
             code.push(line);
           }
-        } else if (qualifies) {
-          line = unescapeBrackets(line);
-          code.push(line);
         }
-      });
-      const codeString = code.join("\n").replace(/\\\\\n/g, "").replace(/\\\n\\/g, "").replace(/\\\n/g, " ");
-      codegenResultArray.push({
-        title: codegenResult.title,
-        language: codegenResult.language,
-        code: codeString
-      });
-      codegenResultRawTemplatesArray.push({
-        title: `${codegenResult.title}: Template (${nodeType})`,
-        language: "PLAINTEXT",
-        code: codegenResult.code
-      });
-    });
+        const codeString = code.join("\n").replace(/\\\\\n/g, "").replace(/\\\n\\/g, "").replace(/\\\n/g, " ");
+        const indentedCodeString = indent + codeString.replace(/\n/g, `
+${indent}`);
+        codegenResultArray.push({
+          title: codegenResult.title,
+          language: codegenResult.language,
+          code: indentedCodeString
+        });
+        codegenResultRawTemplatesArray.push({
+          title: `${codegenResult.title}: Template (${nodeType})`,
+          language: "PLAINTEXT",
+          code: codegenResult.code
+        });
+        return;
+      }
+    );
+    await Promise.all(resultPromises);
     return {
       codegenResultRawTemplatesArray,
       codegenResultArray
     };
+  }
+  async function findChildrenSnippets(codegenResult, nodeChildren, indent, recursionIndex, globalTemplates) {
+    const string = [];
+    const childPromises = nodeChildren.map(async (child) => {
+      const paramsMap = await paramsFromNode(child);
+      const snippets = await nodeSnippetTemplateDataArrayFromNode(
+        child,
+        paramsMap,
+        globalTemplates,
+        indent,
+        recursionIndex + 1
+      );
+      const snippet = snippets.map(
+        (s) => s.codegenResultArray.find(
+          (r) => r.title === codegenResult.title && r.language === codegenResult.language
+        )
+      ).find(Boolean);
+      if (snippet) {
+        string.push(snippet.code);
+      }
+      return;
+    });
+    await Promise.all(childPromises);
+    return string.join("\n");
   }
   function lineConditionalMatch(line, params) {
     const matches = [...line.matchAll(regexConditional)];
@@ -147,7 +529,9 @@
     "{{?1=2|2=3}}1or2": "",
     "{{!1=1}}not1": "",
     "{{!1=2}}not1": "not1",
-    "{{?1=1&2=2}}{{!hello=cheese}}compound": "compound"
+    "{{?1=1&2=2}}{{!hello=cheese}}compound": "compound",
+    "{{1}}{{hello}}{{2}}": "1world2",
+    "{{1}}{{invalid}}{{2}}": ""
   };
   var SNIPPET_TEST_CODE = Object.keys(SNIPPET_TESTS).join("\n");
   var SNIPPET_TEST_CODE_EXPECTATION = Object.values(SNIPPET_TESTS).filter(Boolean).join("\n");
@@ -163,7 +547,11 @@
     const result = await hydrateSnippets(
       [{ language: "PLAINTEXT", code: SNIPPET_TEST_CODE, title: "test" }],
       { params: SNIPPET_TEST_PARAMS, paramsRaw: SNIPPET_TEST_PARAMS },
-      "INSTANCE"
+      "INSTANCE",
+      [],
+      "",
+      0,
+      {}
     );
     const code = result.codegenResultArray[0].code;
     if (code === SNIPPET_TEST_CODE_EXPECTATION) {


### PR DESCRIPTION
first, most simple attempt at nested instances #6. Will get even wilder with global templates. (recursive autolayout component gen). currently requires components to be immediate children and have templates that share the name and language as the parent template.