### PR TITLE
[hotfix] ensures deterministic ordering of templates

### DIFF
--- a/code.js
+++ b/code.js
@@ -162,7 +162,7 @@
     const codegenResultArray = [];
     const codegenResultRawTemplatesArray = [];
     const resultPromises = codegenResultTemplatesArray.map(
-      async (codegenResult) => {
+      async (codegenResult, index) => {
         const lines = codegenResult.code.split("\n");
         const code = [];
         for (let i = 0; i < lines.length; i++) {
@@ -218,16 +218,16 @@
         const codeString = code.join("\n").replace(/\\\\\n/g, "").replace(/\\\n\\/g, "").replace(/\\\n/g, " ");
         const indentedCodeString = indent + codeString.replace(/\n/g, `
 ${indent}`);
-        codegenResultArray.push({
+        codegenResultArray[index] = {
           title: codegenResult.title,
           language: codegenResult.language,
           code: indentedCodeString
-        });
-        codegenResultRawTemplatesArray.push({
+        };
+        codegenResultRawTemplatesArray[index] = {
           title: `${codegenResult.title}: Template (${nodeType})`,
           language: "PLAINTEXT",
           code: codegenResult.code
-        });
+        };
         return;
       }
     );

--- a/src/snippets.ts
+++ b/src/snippets.ts
@@ -216,7 +216,7 @@ export async function hydrateSnippets(
   const codegenResultRawTemplatesArray: CodegenResult[] = [];
 
   const resultPromises = codegenResultTemplatesArray.map(
-    async (codegenResult) => {
+    async (codegenResult, index) => {
       const lines = codegenResult.code.split("\n");
       const code: string[] = [];
       for (let i = 0; i < lines.length; i++) {
@@ -291,17 +291,17 @@ export async function hydrateSnippets(
       const indentedCodeString =
         indent + codeString.replace(/\n/g, `\n${indent}`);
 
-      codegenResultArray.push({
+      codegenResultArray[index] = {
         title: codegenResult.title,
         language: codegenResult.language,
         code: indentedCodeString,
-      });
+      };
 
-      codegenResultRawTemplatesArray.push({
+      codegenResultRawTemplatesArray[index] = {
         title: `${codegenResult.title}: Template (${nodeType})`,
         language: "PLAINTEXT",
         code: codegenResult.code,
-      });
+      };
 
       return;
     }

--- a/test.js
+++ b/test.js
@@ -382,7 +382,7 @@
     const codegenResultArray = [];
     const codegenResultRawTemplatesArray = [];
     const resultPromises = codegenResultTemplatesArray.map(
-      async (codegenResult) => {
+      async (codegenResult, index) => {
         const lines = codegenResult.code.split("\n");
         const code = [];
         for (let i = 0; i < lines.length; i++) {
@@ -438,16 +438,16 @@
         const codeString = code.join("\n").replace(/\\\\\n/g, "").replace(/\\\n\\/g, "").replace(/\\\n/g, " ");
         const indentedCodeString = indent + codeString.replace(/\n/g, `
 ${indent}`);
-        codegenResultArray.push({
+        codegenResultArray[index] = {
           title: codegenResult.title,
           language: codegenResult.language,
           code: indentedCodeString
-        });
-        codegenResultRawTemplatesArray.push({
+        };
+        codegenResultRawTemplatesArray[index] = {
           title: `${codegenResult.title}: Template (${nodeType})`,
           language: "PLAINTEXT",
           code: codegenResult.code
-        });
+        };
         return;
       }
     );


### PR DESCRIPTION
the new async approach allowed for these templates to go in in the wrong order. now they will always come back in the same order that they are defined in the editor.