### PR TITLE
Recursive Params

### DIFF
--- a/src/code.ts
+++ b/src/code.ts
@@ -3,7 +3,7 @@ import {
   getCodegenResultsFromPluginData,
   setCodegenResultsInPluginData,
 } from "./pluginData";
-import { paramsFromNode } from "./params";
+import { recursiveParamsFromNode } from "./params";
 import { nodeSnippetTemplateDataArrayFromNode } from "./snippets";
 import {
   getGlobalTemplatesFromClientStorage,
@@ -78,12 +78,15 @@ function initializeCodegenMode() {
       const hasDefaultMessage = defaultSnippet === "message";
       const currentNode = handleCurrentSelection();
 
-      const paramsMap = await paramsFromNode(currentNode);
       const templates = (await getGlobalTemplatesFromClientStorage()) || {};
+      const recursiveParamsMap = await recursiveParamsFromNode(
+        currentNode,
+        templates
+      );
       const nodeSnippetTemplateDataArray =
         await nodeSnippetTemplateDataArrayFromNode(
           currentNode,
-          paramsMap,
+          recursiveParamsMap,
           templates
         );
 
@@ -98,13 +101,8 @@ function initializeCodegenMode() {
        */
       if (isDetailsMode) {
         snippets.push({
-          title: "Node Params",
-          code: JSON.stringify(paramsMap.params, null, 2),
-          language: "JSON",
-        });
-        snippets.push({
-          title: "Node Params (Raw)",
-          code: JSON.stringify(paramsMap.paramsRaw, null, 2),
+          title: "Params",
+          code: JSON.stringify(recursiveParamsMap, null, 2),
           language: "JSON",
         });
       }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -14,11 +14,23 @@ type CodeSnippetGlobalTemplates = {
 type CodeSnippetParams = { [k: string]: string };
 
 /**
+ * An object of template specific params, only generated when template calls for it.
+ */
+type CodeSnippetParamsTemplateParams = {
+  code: string;
+  children?: CodeSnippetParamsMap[];
+  svg?: string;
+};
+
+/**
  * A map of raw and normalized code snippet params objects. Keys are implicitly the same, values are formatted differently.
  */
 type CodeSnippetParamsMap = {
   paramsRaw: CodeSnippetParams;
   params: CodeSnippetParams;
+  template: {
+    [templateId: string]: CodeSnippetParamsTemplateParams;
+  };
 };
 
 /**

--- a/src/test.ts
+++ b/src/test.ts
@@ -28,6 +28,7 @@ const SNIPPET_TEST_CODE_EXPECTATION = Object.values(SNIPPET_TESTS)
 async function test() {
   try {
     await testSnippets();
+    await recursiveTest();
     return "Tests succeed!";
   } catch (e) {
     throw e;
@@ -37,9 +38,12 @@ async function test() {
 async function testSnippets() {
   const result = await hydrateSnippets(
     [{ language: "PLAINTEXT", code: SNIPPET_TEST_CODE, title: "test" }],
-    { params: SNIPPET_TEST_PARAMS, paramsRaw: SNIPPET_TEST_PARAMS },
+    {
+      params: SNIPPET_TEST_PARAMS,
+      paramsRaw: SNIPPET_TEST_PARAMS,
+      template: {},
+    },
     "INSTANCE",
-    [],
     "",
     0,
     {}
@@ -52,3 +56,416 @@ async function testSnippets() {
 }
 
 test().then(console.log).catch(console.error);
+
+async function recursiveTest() {
+  const params: CodeSnippetParamsMap = {
+    params: {
+      "node.name": "buttons-frame",
+      "node.type": "frame",
+      "node.children": "2",
+      "css.display": "flex",
+      "css.width": "400px",
+      "css.padding":
+        "var(--padding-spacious, 16px) var(--padding-comfortable, 12px)",
+      "css.flexDirection": "column",
+      "css.justifyContent": "center",
+      "css.alignItems": "center",
+      "css.gap": "var(--gap-lg, 16px)",
+      "css.border": "2px solid #E0E0E0",
+      "css.background": "var(--color-bg-subtle, #F0F0F0)",
+      "variables.itemSpacing": "gap-lg",
+      "variables.paddingLeft": "padding-comfortable",
+      "variables.paddingTop": "padding-spacious",
+      "variables.paddingRight": "padding-comfortable",
+      "variables.paddingBottom": "padding-spacious",
+      "variables.fills": "color-bg-subtle",
+      "autolayout.layoutMode": "vertical",
+      "autolayout.paddingLeft": "12",
+      "autolayout.paddingRight": "12",
+      "autolayout.paddingTop": "16",
+      "autolayout.paddingBottom": "16",
+      "autolayout.itemSpacing": "16",
+      "autolayout.primaryAxisAlignItems": "center",
+      "autolayout.counterAxisAlignItems": "center",
+    },
+    paramsRaw: {
+      "node.name": "Buttons Frame",
+      "node.type": "FRAME",
+      "node.children": "2",
+      "css.display": "flex",
+      "css.width": "400px",
+      "css.padding":
+        "var(--padding-spacious, 16px) var(--padding-comfortable, 12px)",
+      "css.flexDirection": "column",
+      "css.justifyContent": "center",
+      "css.alignItems": "center",
+      "css.gap": "var(--gap-lg, 16px)",
+      "css.border": "2px solid #E0E0E0",
+      "css.background": "var(--color-bg-subtle, #F0F0F0)",
+      "variables.itemSpacing": "gap/lg",
+      "variables.paddingLeft": "padding/comfortable",
+      "variables.paddingTop": "padding/spacious",
+      "variables.paddingRight": "padding/comfortable",
+      "variables.paddingBottom": "padding/spacious",
+      "variables.fills": "color/bg-subtle",
+      "autolayout.layoutMode": "VERTICAL",
+      "autolayout.paddingLeft": "12",
+      "autolayout.paddingRight": "12",
+      "autolayout.paddingTop": "16",
+      "autolayout.paddingBottom": "16",
+      "autolayout.itemSpacing": "16",
+      "autolayout.primaryAxisAlignItems": "CENTER",
+      "autolayout.counterAxisAlignItems": "CENTER",
+    },
+    template: {
+      "React-JAVASCRIPT": {
+        code: '<Grid \n  direction="{{autolayout.layoutMode}}"\n  background={theme.{{variables.fills|camel}}}\n  padding=\\{{\\\n{{?variables.paddingTop}}top: theme.{{variables.paddingTop|camel}},\\\n{{!variables.paddingTop}}top: {{autolayout.paddingTop}},\\\n{{?variables.paddingRight}}right: theme.{{variables.paddingRight|camel}},\\\n{{!variables.paddingRight}}right: {{autolayout.paddingRight}},\\\n{{?variables.paddingBottom}}bottom: theme.{{variables.paddingBottom|camel}},\\\n{{!variables.paddingBottom}}bottom: {{autolayout.paddingBottom}},\\\n{{?variables.paddingLeft}}left: theme.{{variables.paddingLeft|camel}}\\\n{{!variables.paddingLeft}}left: {{autolayout.paddingLeft}}\\\n}}\n  {{?variables.itemSpacing}}gap={theme.{{variables.itemSpacing|camel}}}\n  {{!variables.itemSpacing}}gap={{{autolayout.itemSpacing}}}\n  {{?autolayout.layoutMode=horizontal}}verticalAlign="{{autolayout.counterAxisAlignItems}}"\n  {{!autolayout.layoutMode=horizontal}}verticalAlign="{{autolayout.primaryAxisAlignItems}}"\n  {{?autolayout.layoutMode=horizontal}}horizontalAlign="{{autolayout.primaryAxisAlignItems}}"\n  {{!autolayout.layoutMode=horizontal}}horizontalAlign="{{autolayout.counterAxisAlignItems}}"\n{{!figma.children}} />\n{{?figma.children}}>\n  {{figma.children}}\n{{?figma.children}}</Grid>',
+        children: [
+          {
+            params: {
+              "node.name": "heyo-look-at-this",
+              "node.type": "text",
+              "node.characters": "heyo-look-at-this",
+              "node.textStyle": "heading-02",
+              "css.color": "#000",
+              "css.fontFamily": "Inter",
+              "css.fontSize": "36px",
+              "css.fontStyle": "normal",
+              "css.fontWeight": "400",
+              "css.lineHeight": "normal",
+            },
+            paramsRaw: {
+              "node.name": "Heyo look at this",
+              "node.type": "TEXT",
+              "node.characters": "Heyo look at this",
+              "node.textStyle": "Heading 02",
+              "css.color": "#000",
+              "css.fontFamily": "Inter",
+              "css.fontSize": "36px",
+              "css.fontStyle": "normal",
+              "css.fontWeight": "400",
+              "css.lineHeight": "normal",
+            },
+            template: {
+              "React-JAVASCRIPT": {
+                code: '<Typography\\\nvariant="{{node.textStyle}}"\\\n{{!node.textStyle}}variant="unknown"\\\n\\>{{node.characters|raw}}</Typography>',
+              },
+            },
+          },
+          {
+            params: {
+              "node.name": "frame-2",
+              "node.type": "frame",
+              "node.children": "2",
+              "css.display": "flex",
+              "css.justifyContent": "flex-end",
+              "css.alignItems": "center",
+              "css.gap": "var(--gap-md, 12px)",
+              "variables.itemSpacing": "gap-md",
+              "autolayout.layoutMode": "horizontal",
+              "autolayout.paddingLeft": "0",
+              "autolayout.paddingRight": "0",
+              "autolayout.paddingTop": "0",
+              "autolayout.paddingBottom": "0",
+              "autolayout.itemSpacing": "12",
+              "autolayout.primaryAxisAlignItems": "max",
+              "autolayout.counterAxisAlignItems": "center",
+            },
+            paramsRaw: {
+              "node.name": "Frame 2",
+              "node.type": "FRAME",
+              "node.children": "2",
+              "css.display": "flex",
+              "css.justifyContent": "flex-end",
+              "css.alignItems": "center",
+              "css.gap": "var(--gap-md, 12px)",
+              "variables.itemSpacing": "gap/md",
+              "autolayout.layoutMode": "HORIZONTAL",
+              "autolayout.paddingLeft": "0",
+              "autolayout.paddingRight": "0",
+              "autolayout.paddingTop": "0",
+              "autolayout.paddingBottom": "0",
+              "autolayout.itemSpacing": "12",
+              "autolayout.primaryAxisAlignItems": "MAX",
+              "autolayout.counterAxisAlignItems": "CENTER",
+            },
+            template: {
+              "React-JAVASCRIPT": {
+                code: '<Grid \n  direction="{{autolayout.layoutMode}}"\n  background={theme.{{variables.fills|camel}}}\n  padding=\\{{\\\n{{?variables.paddingTop}}top: theme.{{variables.paddingTop|camel}},\\\n{{!variables.paddingTop}}top: {{autolayout.paddingTop}},\\\n{{?variables.paddingRight}}right: theme.{{variables.paddingRight|camel}},\\\n{{!variables.paddingRight}}right: {{autolayout.paddingRight}},\\\n{{?variables.paddingBottom}}bottom: theme.{{variables.paddingBottom|camel}},\\\n{{!variables.paddingBottom}}bottom: {{autolayout.paddingBottom}},\\\n{{?variables.paddingLeft}}left: theme.{{variables.paddingLeft|camel}}\\\n{{!variables.paddingLeft}}left: {{autolayout.paddingLeft}}\\\n}}\n  {{?variables.itemSpacing}}gap={theme.{{variables.itemSpacing|camel}}}\n  {{!variables.itemSpacing}}gap={{{autolayout.itemSpacing}}}\n  {{?autolayout.layoutMode=horizontal}}verticalAlign="{{autolayout.counterAxisAlignItems}}"\n  {{!autolayout.layoutMode=horizontal}}verticalAlign="{{autolayout.primaryAxisAlignItems}}"\n  {{?autolayout.layoutMode=horizontal}}horizontalAlign="{{autolayout.primaryAxisAlignItems}}"\n  {{!autolayout.layoutMode=horizontal}}horizontalAlign="{{autolayout.counterAxisAlignItems}}"\n{{!figma.children}} />\n{{?figma.children}}>\n  {{figma.children}}\n{{?figma.children}}</Grid>',
+                children: [
+                  {
+                    params: {
+                      "property.iconEnd.b": "false",
+                      "property.iconEnd.i": "icon-refresh",
+                      "property.iconStart.b": "false",
+                      "property.iconStart.i": "icon-heart-solid",
+                      "property.label": "cancel",
+                      "property.variant": "inverse",
+                      "property.state": "default",
+                      "property.size": "small",
+                      "node.name": "button",
+                      "node.type": "instance",
+                      "node.children": "1",
+                      "component.key":
+                        "7e95f3069ff381e6d1ea1e34d13d82045be8e249",
+                      "component.type": "component-set",
+                      "component.name": "button",
+                      "css.display": "flex",
+                      "css.padding":
+                        "var(--padding-compact, 4px) var(--padding-spacious, 16px)",
+                      "css.justifyContent": "center",
+                      "css.alignItems": "center",
+                      "css.gap": "var(--gap-sm, 8px)",
+                      "css.borderRadius": "var(--size-24, 24px)",
+                      "css.background": "var(--color-bg-default, #FFF)",
+                      "variables.itemSpacing": "gap-sm",
+                      "variables.paddingLeft": "padding-spacious",
+                      "variables.paddingTop": "padding-compact",
+                      "variables.paddingRight": "padding-spacious",
+                      "variables.paddingBottom": "padding-compact",
+                      "variables.topLeftRadius": "size-24",
+                      "variables.topRightRadius": "size-24",
+                      "variables.bottomLeftRadius": "size-24",
+                      "variables.bottomRightRadius": "size-24",
+                      "variables.fills": "color-bg-default",
+                      "autolayout.layoutMode": "horizontal",
+                      "autolayout.paddingLeft": "16",
+                      "autolayout.paddingRight": "16",
+                      "autolayout.paddingTop": "4",
+                      "autolayout.paddingBottom": "4",
+                      "autolayout.itemSpacing": "8",
+                      "autolayout.primaryAxisAlignItems": "center",
+                      "autolayout.counterAxisAlignItems": "center",
+                    },
+                    paramsRaw: {
+                      "property.iconEnd.b": "false",
+                      "property.iconEnd.i": "Icon Refresh",
+                      "property.iconStart.b": "false",
+                      "property.iconStart.i": "Icon Heart - Solid",
+                      "property.label": "Cancel",
+                      "property.variant": "Inverse",
+                      "property.state": "Default",
+                      "property.size": "Small",
+                      "node.name": "Button",
+                      "node.type": "INSTANCE",
+                      "node.children": "1",
+                      "component.key":
+                        "7e95f3069ff381e6d1ea1e34d13d82045be8e249",
+                      "component.type": "COMPONENT_SET",
+                      "component.name": "Button",
+                      "css.display": "flex",
+                      "css.padding":
+                        "var(--padding-compact, 4px) var(--padding-spacious, 16px)",
+                      "css.justifyContent": "center",
+                      "css.alignItems": "center",
+                      "css.gap": "var(--gap-sm, 8px)",
+                      "css.borderRadius": "var(--size-24, 24px)",
+                      "css.background": "var(--color-bg-default, #FFF)",
+                      "variables.itemSpacing": "gap/sm",
+                      "variables.paddingLeft": "padding/spacious",
+                      "variables.paddingTop": "padding/compact",
+                      "variables.paddingRight": "padding/spacious",
+                      "variables.paddingBottom": "padding/compact",
+                      "variables.topLeftRadius": "size-24",
+                      "variables.topRightRadius": "size-24",
+                      "variables.bottomLeftRadius": "size-24",
+                      "variables.bottomRightRadius": "size-24",
+                      "variables.fills": "color/bg-default",
+                      "autolayout.layoutMode": "HORIZONTAL",
+                      "autolayout.paddingLeft": "16",
+                      "autolayout.paddingRight": "16",
+                      "autolayout.paddingTop": "4",
+                      "autolayout.paddingBottom": "4",
+                      "autolayout.itemSpacing": "8",
+                      "autolayout.primaryAxisAlignItems": "CENTER",
+                      "autolayout.counterAxisAlignItems": "CENTER",
+                    },
+                    template: {
+                      "React-JAVASCRIPT": {
+                        code: '<Button\n  {{?property.state=disabled}}disabled\n  {{!property.size=medium}}size="{{property.size}}"\n  variant="{{property.variant}}"\n  {{?property.iconStart.b=true}}iconStart={<{{property.iconStart.i|pascal}} />}\n  {{?property.iconEnd.b=true}}iconEnd={<{{property.iconEnd.i|pascal}} />}\n  onClick={() => {}}\n>\n  {{property.label|raw}}\n</Button>',
+                      },
+                    },
+                  },
+                  {
+                    params: {
+                      "property.iconEnd.b": "true",
+                      "property.iconEnd.i": "icon-arrow-right",
+                      "property.iconStart.b": "false",
+                      "property.iconStart.i": "icon-heart-solid",
+                      "property.label": "lets-go",
+                      "property.variant": "secondary",
+                      "property.state": "default",
+                      "property.size": "medium",
+                      "node.name": "button",
+                      "node.type": "instance",
+                      "node.children": "2",
+                      "component.key":
+                        "7e95f3069ff381e6d1ea1e34d13d82045be8e249",
+                      "component.type": "component-set",
+                      "component.name": "button",
+                      "css.display": "flex",
+                      "css.padding":
+                        "var(--padding-default, 8px) var(--padding-baggy, 24px)",
+                      "css.justifyContent": "center",
+                      "css.alignItems": "center",
+                      "css.gap": "var(--gap-sm, 8px)",
+                      "css.borderRadius": "var(--size-24, 24px)",
+                      "css.background":
+                        "var(--color-bg-brand-secondary, #7900D5)",
+                      "variables.itemSpacing": "gap-sm",
+                      "variables.paddingLeft": "padding-baggy",
+                      "variables.paddingTop": "padding-default",
+                      "variables.paddingRight": "padding-baggy",
+                      "variables.paddingBottom": "padding-default",
+                      "variables.topLeftRadius": "size-24",
+                      "variables.topRightRadius": "size-24",
+                      "variables.bottomLeftRadius": "size-24",
+                      "variables.bottomRightRadius": "size-24",
+                      "variables.fills": "color-bg-brand-secondary",
+                      "autolayout.layoutMode": "horizontal",
+                      "autolayout.paddingLeft": "24",
+                      "autolayout.paddingRight": "24",
+                      "autolayout.paddingTop": "8",
+                      "autolayout.paddingBottom": "8",
+                      "autolayout.itemSpacing": "8",
+                      "autolayout.primaryAxisAlignItems": "center",
+                      "autolayout.counterAxisAlignItems": "center",
+                    },
+                    paramsRaw: {
+                      "property.iconEnd.b": "true",
+                      "property.iconEnd.i": "Icon Arrow - Right",
+                      "property.iconStart.b": "false",
+                      "property.iconStart.i": "Icon Heart - Solid",
+                      "property.label": "Let's go!",
+                      "property.variant": "Secondary",
+                      "property.state": "Default",
+                      "property.size": "Medium",
+                      "node.name": "Button",
+                      "node.type": "INSTANCE",
+                      "node.children": "2",
+                      "component.key":
+                        "7e95f3069ff381e6d1ea1e34d13d82045be8e249",
+                      "component.type": "COMPONENT_SET",
+                      "component.name": "Button",
+                      "css.display": "flex",
+                      "css.padding":
+                        "var(--padding-default, 8px) var(--padding-baggy, 24px)",
+                      "css.justifyContent": "center",
+                      "css.alignItems": "center",
+                      "css.gap": "var(--gap-sm, 8px)",
+                      "css.borderRadius": "var(--size-24, 24px)",
+                      "css.background":
+                        "var(--color-bg-brand-secondary, #7900D5)",
+                      "variables.itemSpacing": "gap/sm",
+                      "variables.paddingLeft": "padding/baggy",
+                      "variables.paddingTop": "padding/default",
+                      "variables.paddingRight": "padding/baggy",
+                      "variables.paddingBottom": "padding/default",
+                      "variables.topLeftRadius": "size-24",
+                      "variables.topRightRadius": "size-24",
+                      "variables.bottomLeftRadius": "size-24",
+                      "variables.bottomRightRadius": "size-24",
+                      "variables.fills": "color/bg-brand-secondary",
+                      "autolayout.layoutMode": "HORIZONTAL",
+                      "autolayout.paddingLeft": "24",
+                      "autolayout.paddingRight": "24",
+                      "autolayout.paddingTop": "8",
+                      "autolayout.paddingBottom": "8",
+                      "autolayout.itemSpacing": "8",
+                      "autolayout.primaryAxisAlignItems": "CENTER",
+                      "autolayout.counterAxisAlignItems": "CENTER",
+                    },
+                    template: {
+                      "React-JAVASCRIPT": {
+                        code: '<Button\n  {{?property.state=disabled}}disabled\n  {{!property.size=medium}}size="{{property.size}}"\n  variant="{{property.variant}}"\n  {{?property.iconStart.b=true}}iconStart={<{{property.iconStart.i|pascal}} />}\n  {{?property.iconEnd.b=true}}iconEnd={<{{property.iconEnd.i|pascal}} />}\n  onClick={() => {}}\n>\n  {{property.label|raw}}\n</Button>',
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      },
+    },
+  };
+  const template = `<Grid 
+  direction="{{autolayout.layoutMode}}"
+  background={theme.{{variables.fills|camel}}}
+  padding=\\{{\\
+{{?variables.paddingTop}}top: theme.{{variables.paddingTop|camel}},\\
+{{!variables.paddingTop}}top: {{autolayout.paddingTop}},\\
+{{?variables.paddingRight}}right: theme.{{variables.paddingRight|camel}},\\
+{{!variables.paddingRight}}right: {{autolayout.paddingRight}},\\
+{{?variables.paddingBottom}}bottom: theme.{{variables.paddingBottom|camel}},\\
+{{!variables.paddingBottom}}bottom: {{autolayout.paddingBottom}},\\ 
+{{?variables.paddingLeft}}left: theme.{{variables.paddingLeft|camel}}\\
+{{!variables.paddingLeft}}left: {{autolayout.paddingLeft}}\\
+}}
+  {{?variables.itemSpacing}}gap={theme.{{variables.itemSpacing|camel}}}
+  {{!variables.itemSpacing}}gap={{{autolayout.itemSpacing}}}
+  {{?autolayout.layoutMode=horizontal}}verticalAlign="{{autolayout.counterAxisAlignItems}}"
+  {{!autolayout.layoutMode=horizontal}}verticalAlign="{{autolayout.primaryAxisAlignItems}}"
+  {{?autolayout.layoutMode=horizontal}}horizontalAlign="{{autolayout.primaryAxisAlignItems}}"
+  {{!autolayout.layoutMode=horizontal}}horizontalAlign="{{autolayout.counterAxisAlignItems}}"
+{{!figma.children}} />
+{{?figma.children}}>
+  {{figma.children}}
+{{?figma.children}}</Grid>`;
+  const expectation = `<Grid 
+  direction="vertical"
+  background={theme.colorBgSubtle}
+  padding={{ top: theme.paddingSpacious, right: theme.paddingComfortable, bottom: theme.paddingSpacious, left: theme.paddingComfortable }}
+  gap={theme.gapLg}
+  verticalAlign="center"
+  horizontalAlign="center"
+>
+  <Typography variant="heading-02">Heyo look at this</Typography>
+  <Grid 
+    direction="horizontal"
+    padding={{ top: 0, right: 0, bottom: 0, left: 0 }}
+    gap={theme.gapMd}
+    verticalAlign="center"
+    horizontalAlign="max"
+  >
+    <Button
+      size="small"
+      variant="inverse"
+      onClick={() => {}}
+    >
+      Cancel
+    </Button>
+    <Button
+      variant="secondary"
+      iconEnd={<IconArrowRight />}
+      onClick={() => {}}
+    >
+      Let's go!
+    </Button>
+  </Grid>
+</Grid>`;
+  const result = await hydrateSnippets(
+    [{ language: "JAVASCRIPT", code: template, title: "React" }],
+    params,
+    "FRAME",
+    "",
+    0,
+    {}
+  );
+  const code = result.codegenResultArray[0].code;
+  if (code === expectation) {
+    return true;
+  }
+  const expectationLines = expectation.split("\n");
+  const codeLines = code.split("\n");
+  const diff: string[] = [];
+  expectationLines.forEach((line, i) => {
+    if (line !== codeLines[i]) {
+      diff.push(["E: " + line, "R: " + codeLines[i]].join("\n"));
+    }
+  });
+  throw `Snippet hydration broken.
+
+${diff.join("\n\n")}
+`;
+}


### PR DESCRIPTION
Working to improve params generation per #48 

Essentially, we are generating all the params (including recursive children) upfront before compiling templates.

Until now, params generation and children traversal has been coupled to compilation making it hard to test and certain statements impossible. "will any of this node's children render in this template?" is a better and different question than, "does this node have children with a snippet template?" which is different than the more primitive and currently supported, "does this node have children?"

This is no longer a limitation, allowing statements like `{{?figma.children}}` (if any children will render for this template) and `{{!figma.children}}` (if no children render for this template).

See test.ts for a sense of what's possible. Params objects can contain children and child templates. They hydrate templates and can be compared to expected strings. This means we can test and preview full recursive template compilation outside the Figma environment. 

Still have some cleanup to do, but this is a big first step towards optimal params generation.