### PR TITLE
Handles multiple bound variables.

### DIFF
--- a/code.js
+++ b/code.js
@@ -614,18 +614,31 @@ ${indent}`);
           if (!Array.isArray(vars)) {
             vars = [vars];
           }
-          vars.forEach((v) => {
+          const doIndexes = vars.length > 1;
+          vars.forEach((v, i) => {
             const va = figma.variables.getVariableById(v.id);
             if (va) {
-              paramsRaw[`variables.${key}`] = va.name;
-              params[`variables.${key}`] = safeString(va.name);
+              if (i === 0) {
+                paramsRaw[`variables.${key}`] = va.name;
+                params[`variables.${key}`] = safeString(va.name);
+              }
+              if (doIndexes) {
+                paramsRaw[`variables.${key}.${i}`] = va.name;
+                params[`variables.${key}.${i}`] = safeString(va.name);
+              }
               for (let syntax in va.codeSyntax) {
                 const syntaxKey = syntax.charAt(0).toLowerCase();
                 const syntaxName = syntax;
                 const value = va.codeSyntax[syntaxName];
                 if (value) {
-                  paramsRaw[`variables.${key}.${syntaxKey}`] = value;
-                  params[`variables.${key}.${syntaxKey}`] = safeString(value);
+                  if (i === 0) {
+                    paramsRaw[`variables.${key}.${syntaxKey}`] = value;
+                    params[`variables.${key}.${syntaxKey}`] = safeString(value);
+                  }
+                  if (doIndexes) {
+                    paramsRaw[`variables.${key}.${i}.${syntaxKey}`] = value;
+                    params[`variables.${key}.${i}.${syntaxKey}`] = safeString(value);
+                  }
                 }
               }
             }

--- a/code.js
+++ b/code.js
@@ -614,17 +614,12 @@ ${indent}`);
           if (!Array.isArray(vars)) {
             vars = [vars];
           }
-          const doIndexes = vars.length > 1;
           vars.forEach((v, i) => {
             const va = figma.variables.getVariableById(v.id);
             if (va) {
               if (i === 0) {
                 paramsRaw[`variables.${key}`] = va.name;
                 params[`variables.${key}`] = safeString(va.name);
-              }
-              if (doIndexes) {
-                paramsRaw[`variables.${key}.${i}`] = va.name;
-                params[`variables.${key}.${i}`] = safeString(va.name);
               }
               for (let syntax in va.codeSyntax) {
                 const syntaxKey = syntax.charAt(0).toLowerCase();
@@ -635,12 +630,12 @@ ${indent}`);
                     paramsRaw[`variables.${key}.${syntaxKey}`] = value;
                     params[`variables.${key}.${syntaxKey}`] = safeString(value);
                   }
-                  if (doIndexes) {
-                    paramsRaw[`variables.${key}.${i}.${syntaxKey}`] = value;
-                    params[`variables.${key}.${i}.${syntaxKey}`] = safeString(value);
-                  }
+                  paramsRaw[`variables.${key}.${i}.${syntaxKey}`] = value;
+                  params[`variables.${key}.${i}.${syntaxKey}`] = safeString(value);
                 }
               }
+              paramsRaw[`variables.${key}.${i}`] = va.name;
+              params[`variables.${key}.${i}`] = safeString(va.name);
             }
           });
         }

--- a/src/params.ts
+++ b/src/params.ts
@@ -270,17 +270,12 @@ async function initialParamsFromNode(
         if (!Array.isArray(vars)) {
           vars = [vars];
         }
-        const doIndexes = vars.length > 1;
         vars.forEach((v, i) => {
           const va = figma.variables.getVariableById(v.id);
           if (va) {
             if (i === 0) {
               paramsRaw[`variables.${key}`] = va.name;
               params[`variables.${key}`] = safeString(va.name);
-            }
-            if (doIndexes) {
-              paramsRaw[`variables.${key}.${i}`] = va.name;
-              params[`variables.${key}.${i}`] = safeString(va.name);
             }
             for (let syntax in va.codeSyntax) {
               const syntaxKey = syntax.charAt(0).toLowerCase();
@@ -291,13 +286,13 @@ async function initialParamsFromNode(
                   paramsRaw[`variables.${key}.${syntaxKey}`] = value;
                   params[`variables.${key}.${syntaxKey}`] = safeString(value);
                 }
-                if (doIndexes) {
-                  paramsRaw[`variables.${key}.${i}.${syntaxKey}`] = value;
-                  params[`variables.${key}.${i}.${syntaxKey}`] =
-                    safeString(value);
-                }
+                paramsRaw[`variables.${key}.${i}.${syntaxKey}`] = value;
+                params[`variables.${key}.${i}.${syntaxKey}`] =
+                  safeString(value);
               }
             }
+            paramsRaw[`variables.${key}.${i}`] = va.name;
+            params[`variables.${key}.${i}`] = safeString(va.name);
           }
         });
       }

--- a/src/params.ts
+++ b/src/params.ts
@@ -270,18 +270,32 @@ async function initialParamsFromNode(
         if (!Array.isArray(vars)) {
           vars = [vars];
         }
-        vars.forEach((v) => {
+        const doIndexes = vars.length > 1;
+        vars.forEach((v, i) => {
           const va = figma.variables.getVariableById(v.id);
           if (va) {
-            paramsRaw[`variables.${key}`] = va.name;
-            params[`variables.${key}`] = safeString(va.name);
+            if (i === 0) {
+              paramsRaw[`variables.${key}`] = va.name;
+              params[`variables.${key}`] = safeString(va.name);
+            }
+            if (doIndexes) {
+              paramsRaw[`variables.${key}.${i}`] = va.name;
+              params[`variables.${key}.${i}`] = safeString(va.name);
+            }
             for (let syntax in va.codeSyntax) {
               const syntaxKey = syntax.charAt(0).toLowerCase();
               const syntaxName = syntax as "WEB" | "ANDROID" | "iOS";
               const value = va.codeSyntax[syntaxName];
               if (value) {
-                paramsRaw[`variables.${key}.${syntaxKey}`] = value;
-                params[`variables.${key}.${syntaxKey}`] = safeString(value);
+                if (i === 0) {
+                  paramsRaw[`variables.${key}.${syntaxKey}`] = value;
+                  params[`variables.${key}.${syntaxKey}`] = safeString(value);
+                }
+                if (doIndexes) {
+                  paramsRaw[`variables.${key}.${i}.${syntaxKey}`] = value;
+                  params[`variables.${key}.${i}.${syntaxKey}`] =
+                    safeString(value);
+                }
               }
             }
           }


### PR DESCRIPTION
For things like gradient stops, there can be multiple bound variables for fills. Now handling this with an index suffix in the params. `variables.fills` is unchanged, these are additional values:

```js
{
  // Today's values still exist for backwards compatibility
  "variables.fills": "icon-assistive",
  "variables.fills.w": "var(--color-icon-assistive)",
  // New values
  "variables.fills.0": "icon-assistive", // Same value as variables.fills, but the indexed version.
  "variables.fills.0.w": "var(--color-icon-assistive)", // The web syntax for variables.fills.0
  "variables.fills.1": "icon-danger", // The second fill bound variable
  "variables.fills.1.w": "var(--color-icon-danger)" // The web syntax for it
}
```